### PR TITLE
Bug 1232619 - [TV][2.5] Update preview area's background color

### DIFF
--- a/src/media/css/app-preview.styl
+++ b/src/media/css/app-preview.styl
@@ -4,6 +4,8 @@
 
 @import 'lib';
 
+$app-preview-background-color = #72C9B0;
+
 .app-preview {
     position: absolute;
     top: 0;
@@ -13,6 +15,7 @@
     height: $app-preview-height;
     padding: 7.2rem 18.5rem 6.9rem 15rem;
 
+    background-color: $app-preview-background-color;
     background-image: url('../img/pattern-overlay.png');
 
     .preview,


### PR DESCRIPTION
This is a follow up bug for [Bug 1227929](https://bugzilla.mozilla.org/show_bug.cgi?id=1227929).

In order to meet the project deadline, we will use a fixed background color for now.
See the updated visual spec [here](http://bit.ly/1lr4WNu).
