### PR TITLE
Bug 1233681 - [TV][2.5] Update contextmenu id to the top element

### DIFF
--- a/src/dev.html
+++ b/src/dev.html
@@ -27,12 +27,16 @@
     </script>
   </head>
 
-  <body class="home" data-media="">
+  <body class="home" data-media="" contextmenu="contextmenu">
     <noscript><p>Sorry, you need JavaScript to use this site.</p></noscript>
 
     <main>
       <div id="page" class="page" role="main"></div>
     </main>
+
+    <menu type="context" id="contextmenu">
+      <menuitem></menuitem>
+    </menu>
 
     {% if compiled %}
       <script src="/media/js/include.js" defer></script>

--- a/src/media/js/views/homepage.js
+++ b/src/media/js/views/homepage.js
@@ -6,6 +6,8 @@ define('views/homepage',
     var gettext = l10n.gettext;
     var appsModel = models('apps');
 
+    var appContextMenu = document.getElementById('contextmenu').children[0];
+
     var $appPreview;
     var $appList;
 
@@ -69,6 +71,9 @@ define('views/homepage',
 
         var focusedApp = appsModel.lookup(this.dataset.slug);
         var focusedManifestURL = focusedApp.manifest_url;
+
+        // Update context menu's label
+        appContextMenu.label = focusedManifestURL || '';
 
         this.classList.add('focused');
 

--- a/src/templates/homepage.html
+++ b/src/templates/homepage.html
@@ -4,16 +4,10 @@
   {% defer (url=api('apps'), pluck='objects', as='apps', key='slug') %}
     <ul class="clearfix">
       {% for app in this %}
-        <li class="app-list-app focusable" data-slug="{{ app.slug }}"
-            contextmenu="contextmenu-{{ loop.index }}">
+        <li class="app-list-app focusable" data-slug="{{ app.slug }}">
           <img src="{{ app.icons['128'] }}"
                alt="{{ app.name }}" title="{{ app.name }}">
           <span class="name">{{ app.name }}</span>
-
-          <menu type="context" id="contextmenu-{{ loop.index }}">
-            <menuitem label="{{ app.manifest_url }}"></menuitem>
-          </menu>
-
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Instead of using multiple menu inside each app's icon, we turn up to use a single menu and update its label dynamically by javascript when an app is focused.

This is a compromise with Panasonic TV. See this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1233681) for more details.
