### PR TITLE
Bug 1235116 - [TV][2.5] Open or press option key on website

### DIFF
--- a/src/templates/homepage.html
+++ b/src/templates/homepage.html
@@ -5,8 +5,20 @@
     <ul class="clearfix">
       {% for app in this %}
         <li class="app-list-app focusable" data-slug="{{ app.slug }}">
-          <img src="{{ app.icons['128'] }}"
-               alt="{{ app.name }}" title="{{ app.name }}">
+          {% if app.icons['128'] %}
+            <img src="{{ app.icons['128'] }}"
+                 alt="{{ app.name }}" title="{{ app.name }}">
+          {% elif app.icons['64'] %}
+            <img src="{{ app.icons['64'] }}"
+                 alt="{{ app.name }}" title="{{ app.name }}">
+          {% elif app.icons['48'] %}
+            <img src="{{ app.icons['48'] }}"
+                 alt="{{ app.name }}" title="{{ app.name }}">
+          {% elif app.icons['32'] %}
+            <img src="{{ app.icons['32'] }}"
+                 alt="{{ app.name }}" title="{{ app.name }}">
+          {% endif %}
+
           <span class="name">{{ app.name }}</span>
         </li>
       {% endfor %}


### PR DESCRIPTION
When open website, use window.open to open the website url and tailing with query strings including remote=true, preview=true, encoded app's name and icon url.

When press option key on website, change the contextmenu's label with encoded website url, app name and icon url.
