### PR TITLE
Bug 1235135 - [TV][2.5] Hide price text in preview area

### DIFF
--- a/src/media/js/views/homepage.js
+++ b/src/media/js/views/homepage.js
@@ -105,8 +105,6 @@ define('views/homepage',
         $appPreviewPrice = $appPreview.find('.price');
 
         if (!caps.webApps) {
-            $appPreviewPrice.removeClass('hidden');
-
             return;
         }
 
@@ -117,8 +115,6 @@ define('views/homepage',
                     $appPreviewPrice.addClass('installed');
                 }
             });
-
-            $appPreviewPrice.removeClass('hidden');
         });
     });
 


### PR DESCRIPTION
According to [comment 2](https://bugzilla.mozilla.org/show_bug.cgi?id=1235135#c2) in this bug, we cannot get the install status of websites. Therefore, we decide to hide the price text for now as we are closed to the project deadline.
