### PR TITLE
Bug 1237888 - [TV][2.5] Price text should always show 'Free'

### DIFF
--- a/src/media/js/views/homepage.js
+++ b/src/media/js/views/homepage.js
@@ -169,18 +169,7 @@ define('views/homepage',
             carousel();
         }
 
-        if (!caps.webApps) {
-            return;
-        }
-
-        // Update type when app is already installed.
-        apps.getInstalled().done(function(installedApps) {
-            installedApps.map(function(installedManifestURL) {
-                if (installedManifestURL === focusedManifestURL) {
-                    $appPreviewPrice.addClass('installed');
-                }
-            });
-        });
+        $appPreviewPrice.removeClass('hidden');
     });
 
     z.page.on('keydown mousedown touchstart', '.focusable', function(e) {


### PR DESCRIPTION
Instead of hiding the price text, the UX team decides to show the string 'Free' at all times (no matter the app is installed or not).
