### PR TITLE
Bug 1250075 - [TV][2.5] FTE of WebApps shows "Add to Apps", but not translated and strings are within Card

### DIFF
--- a/src/media/css/tutorial.styl
+++ b/src/media/css/tutorial.styl
@@ -134,9 +134,24 @@
             display: block;
             width: 9rem;
             height: 9rem;
-            margin: 0 auto 1.3rem;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
 
             background-image: url('../img/tutorial_install.png');
+        }
+
+        &-label {
+            position: absolute;
+            bottom: -3.5rem;
+            left: 50%;
+            transform: translate(-50%, 0);
+
+            font-size: 1.5rem;
+            font-style: italic;
+
+            color: #fff;
         }
     }
 

--- a/src/templates/tutorial.html
+++ b/src/templates/tutorial.html
@@ -15,7 +15,7 @@
         <div class="slide-image slide-image-0{{ i }}"></div>
         {% if i == 2 %}
           <div class="circle">
-            <span>{{ _('Add to Apps') }}</span>
+            <div class="circle-label">{{ _('Add to Apps') }}</div>
           </div>
         {% elif i == 3 %}
           <span class="text">{{ _('Apps') }}</span>


### PR DESCRIPTION
This patch based on the latest UI specs updates:
- Put  the tutorial install icon in the centre of the white circle
- Put the "Add to apps" label text below 1.5rem of the white circle
